### PR TITLE
Add default "keywords" to bower.json and package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,11 +96,11 @@ included in the project:
 
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone https://github.com/<your-username>/generator-flight
+   git clone https://github.com/<your-username>/generator-flight-package
    # Navigate to the newly cloned directory
    cd generator-flight
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/twitter/generator-flight
+   git remote add upstream https://github.com/flightjs/generator-flight-package
    ```
 
 2. If you cloned a while ago, get the latest changes from upstream:

--- a/lib/templates/bower.json
+++ b/lib/templates/bower.json
@@ -1,6 +1,10 @@
 {
   "name": "flight-<%= name %>",
   "version": "0.0.0",
+  "keywords": [
+    "flight-component",
+    "flight-<%= name %>"
+  ],
   "main": "lib/<%= name %>.js",
   "dependencies": {
     "flight": "~1.1.0"

--- a/lib/templates/package.json
+++ b/lib/templates/package.json
@@ -1,6 +1,10 @@
 {
   "name": "flight-<%= name %>",
   "version": "0.0.0",
+  "keywords": [
+    "flight-component",
+    "flight-<%= name %>"
+  ],
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-bump": "latest",


### PR DESCRIPTION
so that people (and http://flight-components.jit.su) can search by keyword rather than title.
The default keywords are "flight-component" and "flight-<%= name %>" 
where <%= name %> is the package name obviously.

It also fixes wrong urls in CONTRIBUTING.md
